### PR TITLE
Add TravisCI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: clojure
 env:
   global:
     - "GALAXY_APIKEY=admin"
-    - "GALAXY_URL=http://localhost:8080"
+    - "GALAXY_URL=http://localhost:8080/api/"
   matrix:
-    - "GALAXY_VERSION=18.05"
+    - "GALAXY_VERSION=19.05"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+
+language: clojure
+
+env:
+  global:
+    - "GALAXY_APIKEY=admin"
+    - "GALAXY_URL=http://localhost:8080"
+  matrix:
+    - "GALAXY_VERSION=18.05"
+
+services:
+  - docker
+  
+before_install:
+  - docker pull bgruening/galaxy-stable:$GALAXY_VERSION
+  - docker run -d -p 8080:80 -e GALAXY_CONFIG_MASTER_API_KEY=$GALAXY_APIKEY bgruening/galaxy-stable:$GALAXY_VERSION
+  - docker ps
+  - sleep 180
+
+script: lein test


### PR DESCRIPTION
Adds a TravisCI config that sets up a basic [galaxy-stable](https://github.com/bgruening/docker-galaxy-stable) docker image and runs the unit test suite against it.